### PR TITLE
Fix Pkey RSA constructor again

### DIFF
--- a/lib/keystores/jks/pkcs8_key.rb
+++ b/lib/keystores/jks/pkcs8_key.rb
@@ -60,8 +60,10 @@ module OpenSSL
     class RSA
       original_initialize = instance_method(:initialize)
 
-      define_method(:initialize) do |der_or_pem, pass_phrase = nil|
+      define_method(:initialize) do |der_or_pem = nil, pass_phrase = nil|
         init = original_initialize.bind(self)
+        return init.() unless der_or_pem # Create a dummy empty key if not passed an argument
+
         begin
           init.(der_or_pem, pass_phrase)
         rescue Exception

--- a/lib/keystores/version.rb
+++ b/lib/keystores/version.rb
@@ -1,3 +1,3 @@
 module Keystores
-  VERSION = '0.4.0'
+  VERSION = '0.4.2'
 end


### PR DESCRIPTION
net-ssh constructs the pkey without passing in any argument, which results
in a dummy key (it's up to the caller to populate the key in this case, which
is what net-ssh does). This commit handles this constructor case.

This is not documented in https://ruby-doc.org/stdlib-2.1.6/libdoc/openssl/rdoc/OpenSSL/PKey/RSA.html
but does work in vanilla Ruby (probably because this is a built-in C method).

Our keystores override still doesn't support constructing a key passing in the size (the
library we forked from didn't, and apparently we don't need to... yet).

This has been tested and seems to work.